### PR TITLE
Updated spack packages and added issm to injection

### DIFF
--- a/config/packages.json
+++ b/config/packages.json
@@ -5,6 +5,7 @@
   ],
   "injection": [
     "openmpi",
+    "issm",
     "access-triangle"
   ]
 }

--- a/config/packages.json
+++ b/config/packages.json
@@ -5,7 +5,6 @@
   ],
   "injection": [
     "openmpi",
-    "issm",
     "access-triangle"
   ]
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.04.001"
+    "spack-packages": "2025.09.004"
 }


### PR DESCRIPTION
Testing updating the spack packages and injection issm to solve python import issues. 

Basically a sanity check for my own mental health due to #22 failing to build.

---
:rocket: The latest prerelease `access-issm/pr24-2` at b42a554e7c5ea879c1053a3a70f5598dfabb3553 is here: https://github.com/ACCESS-NRI/ACCESS-ISSM/pull/24#issuecomment-3396007036 :rocket:


