### PR TITLE
Testing upstream ISSM update & new spack-variant

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.10.001"
+    "spack-packages": "lb/fix-ad-variant"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "lb/fix-ad-variant"
+    "spack-packages": "a2232058dcd21ceb34bc820898daa717923c628b"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "b6181a7495a6fdf7b7a071d6f3d8c9c753e16a87"
+    "spack-packages": "2025.10.001"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.04.001"
+    "spack-packages": "b6181a7495a6fdf7b7a071d6f3d8c9c753e16a87"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "a2232058dcd21ceb34bc820898daa717923c628b"
+    "spack-packages": "3ae3eac7206c342746cfb439bda0e520569d60ae"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "3ae3eac7206c342746cfb439bda0e520569d60ae"
+    "spack-packages": "9ff20ba9201f0552c7f50b2db1e2f9458da3e004"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -7,6 +7,7 @@ spack:
         - '@git.7f75a90562fae6834a33bdc6276eaa5dc2cbcf66'
         - +wrappers
         - +py-tools
+        - +ad
     # Mark Python 3.9.2 as external so Spack reuses the system module
     python:
       externals:

--- a/spack.yaml
+++ b/spack.yaml
@@ -7,7 +7,6 @@ spack:
         - '@git.2025.04.11'
         - +wrappers
         - +py-tools
-        - ~ad
     # Mark Python 3.9.2 as external so Spack reuses the system module
     python:
       externals:

--- a/spack.yaml
+++ b/spack.yaml
@@ -7,6 +7,7 @@ spack:
         - '@git.2025.04.11'
         - +wrappers
         - +py-tools
+        - ~ad
     # Mark Python 3.9.2 as external so Spack reuses the system module
     python:
       externals:

--- a/spack.yaml
+++ b/spack.yaml
@@ -7,7 +7,6 @@ spack:
         - '@git.7f75a90562fae6834a33bdc6276eaa5dc2cbcf66'
         - +wrappers
         - +py-tools
-        - +ad
     # Mark Python 3.9.2 as external so Spack reuses the system module
     python:
       externals:

--- a/spack.yaml
+++ b/spack.yaml
@@ -7,6 +7,7 @@ spack:
         - '@git.7f75a90562fae6834a33bdc6276eaa5dc2cbcf66'
         - +wrappers
         - +py-tools
+        - ~ad
     # Mark Python 3.9.2 as external so Spack reuses the system module
     python:
       externals:

--- a/spack.yaml
+++ b/spack.yaml
@@ -4,7 +4,7 @@ spack:
   packages:
     issm:
       require:
-        - '@git.7f75a90562fae6834a33bdc6276eaa5dc2cbcf66'
+        - '@git.2025.04.11'
         - +wrappers
         - +py-tools
     # Mark Python 3.9.2 as external so Spack reuses the system module

--- a/spack.yaml
+++ b/spack.yaml
@@ -7,8 +7,6 @@ spack:
         - '@git.7f75a90562fae6834a33bdc6276eaa5dc2cbcf66'
         - +wrappers
         - +py-tools
-        - ~ad
-        - +openmp
     # Mark Python 3.9.2 as external so Spack reuses the system module
     python:
       externals:

--- a/spack.yaml
+++ b/spack.yaml
@@ -7,6 +7,7 @@ spack:
         - '@git.2025.04.11'
         - +wrappers
         - +py-tools
+        - +ad
     # Mark Python 3.9.2 as external so Spack reuses the system module
     python:
       externals:

--- a/spack.yaml
+++ b/spack.yaml
@@ -4,10 +4,9 @@ spack:
   packages:
     issm:
       require:
-        - '@git.2025.04.11'
+        - '@git.7f75a90562fae6834a33bdc6276eaa5dc2cbcf66'
         - +wrappers
         - +py-tools
-        - +ad
     # Mark Python 3.9.2 as external so Spack reuses the system module
     python:
       externals:

--- a/spack.yaml
+++ b/spack.yaml
@@ -4,7 +4,7 @@ spack:
   packages:
     issm:
       require:
-        - '@git.2025.04.11'
+        - '@git.7f75a90562fae6834a33bdc6276eaa5dc2cbcf66'
         - +wrappers
         - +py-tools
         - ~ad

--- a/spack.yaml
+++ b/spack.yaml
@@ -4,7 +4,7 @@ spack:
   packages:
     issm:
       require:
-        - '@git.7f75a90562fae6834a33bdc6276eaa5dc2cbcf66'
+        - '@git.2025.04.11'
         - +wrappers
         - +py-tools
         - ~ad

--- a/spack.yaml
+++ b/spack.yaml
@@ -8,6 +8,7 @@ spack:
         - +wrappers
         - +py-tools
         - ~ad
+        - +openmp
     # Mark Python 3.9.2 as external so Spack reuses the system module
     python:
       externals:

--- a/spack.yaml
+++ b/spack.yaml
@@ -4,8 +4,9 @@ spack:
   packages:
     issm:
       require:
-        - '@git.2025.04.11'
+        - '@git.7f75a90562fae6834a33bdc6276eaa5dc2cbcf66'
         - +wrappers
+        - +py-tools
     # Mark Python 3.9.2 as external so Spack reuses the system module
     python:
       externals:


### PR DESCRIPTION
This draft PR tests a new build of ACCESS-ISSM based on an [updated ISSM code base](https://github.com/ACCESS-NRI/ISSM/pull/8). It also integrates updates to the ISSM spack-package that have been implemented [here](https://github.com/ACCESS-NRI/spack-packages/pull/336).

---
:rocket: The latest prerelease `access-issm/pr26-3` at 45ffe58649b34234d868c774cc6dc8f028a57a23 is here: https://github.com/ACCESS-NRI/ACCESS-ISSM/pull/26#issuecomment-3458817801 :rocket:






















