### PR TITLE
Testing gadi modules

### DIFF
--- a/config/packages.json
+++ b/config/packages.json
@@ -4,6 +4,12 @@
     "issm"
   ],
   "injection": [
-    "access-triangle"
+    "access-triangle",
+    "open-mpi",
+    "petsc",
+    "netcdf",
+    "hdf5",
+    "intel-mkl",
+    "python"
   ]
 }

--- a/config/packages.json
+++ b/config/packages.json
@@ -4,7 +4,6 @@
     "issm"
   ],
   "injection": [
-    "openmpi",
     "access-triangle"
   ]
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "c98c8227668d4ea6804fb19819128ed82d23307f"
+    "spack-packages": "142f9ce2a10f4d3445e06c8b98c198f2ebdb4a15"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "e11d00722d43852828f74804ccac0540c1512b76"
+    "spack-packages": "80d4a1c1ce81d34b078ed0cde6b023bdc230bd3b"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "43234c966b3436bad2d13db93bc7dd3a37569434"
+    "spack-packages": "c98c8227668d4ea6804fb19819128ed82d23307f"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "16569139a0511b57536daad845c5e2087be66763"
+    "spack-packages": "e11d00722d43852828f74804ccac0540c1512b76"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "7680c72a558e9b13961c6855a8649bcfe7fd1f8c"
+    "spack-packages": "43234c966b3436bad2d13db93bc7dd3a37569434"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "80d4a1c1ce81d34b078ed0cde6b023bdc230bd3b"
+    "spack-packages": "7680c72a558e9b13961c6855a8649bcfe7fd1f8c"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.04.001"
+    "spack-packages": "16569139a0511b57536daad845c5e2087be66763"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -26,10 +26,6 @@ spack:
         prefix: /apps/openmpi/4.1.3
         modules: [openmpi/4.1.3]
       buildable: false
-      extra_attributes:
-        environment:
-          prepend_path:
-            CMAKE_PREFIX_PATH: /apps/openmpi/4.1.3/include/GNU
 
     petsc:
       externals:

--- a/spack.yaml
+++ b/spack.yaml
@@ -53,6 +53,9 @@ spack:
       - spec: python@3.9.2
         prefix: /apps/python3/3.9.2
         modules: [python3/3.9.2]
+        environment:
+          set:
+            LD_LIBRARY_PATH: /apps/python3/3.9.2/lib
       buildable: false
 
     intel-mkl:

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,7 +22,7 @@ spack:
 
     openmpi:
       externals:
-      - spec: openmpi@4.1.3 %gcc
+      - spec: openmpi@4.1.3
         prefix: /apps/openmpi/4.1.3
         modules: [openmpi/4.1.3]
       buildable: false
@@ -54,3 +54,11 @@ spack:
         prefix: /apps/python3/3.9.2
         modules: [python3/3.9.2]
       buildable: false
+
+    intel-mkl:
+      externals:
+      - spec: intel-mkl@2022.2.0
+        prefix: /apps/intel-ct/2022.2.0/mkl
+        modules: [intel-mkl/2022.2.0]
+      buildable: false
+

--- a/spack.yaml
+++ b/spack.yaml
@@ -1,29 +1,60 @@
 spack:
   specs:
-    - access-issm@git.2025.03.0
-  packages:
-    issm:
-      require:
-        - '@git.2025.04.11'
-        - +wrappers
-    # Mark Python 3.9.2 as external so Spack reuses the system module
-    python:
-      externals:
-        - spec: python@3.9.2
-          modules:
-            - python3/3.9.2
-          prefix: /apps/python3/3.9.2
-      buildable: false
-    openmpi:
-      require:
-        - '@4.1.7'
-    # “all” can remain empty if you aren’t forcing any particular compiler / MPI
-    all:
-      require:
-        - '%gcc@13'
-        - 'target=x86_64'
+    - access-issm@git.2025.06.0
+
   # Create a unified view of all installed packages
   view: true
   # Make the solver unify dependencies
   concretizer:
     unify: true
+
+  packages:
+    all:
+      require:
+        - '%gcc@13'
+        - 'target=x86_64'
+
+    issm:
+      require:
+        - '@git.d52ab3f049920f1a5b0432938f1279ba09c3a8cf'
+        - +wrappers
+        - +py-tools
+
+    openmpi:
+      externals:
+      - spec: openmpi@4.1.3 %gcc
+      prefix: /apps/openmpi/4.1.3
+      modules: [openmpi/4.1.3]
+        buildable: false
+      extra_attributes:
+        environment:
+          prepend_path:
+            CMAKE_PREFIX_PATH: /apps/openmpi/4.1.3/include/GNU
+
+    petsc:
+      externals:
+      - spec: petsc@3.17.4
+        prefix: /apps/petsc/3.17.4
+        modules: [petsc/3.17.4]
+      buildable: false
+
+    netcdf:
+      externals:
+      - spec: netcdf@4.8.0
+        prefix: /apps/netcdf/4.8.0p
+        modules: [netcdf/4.8.0]
+      buildable: false
+
+    hdf5:
+      externals:
+      - spec: hdf5@1.10.7
+        prefix: /apps/hdf5/1.10.7p
+        modules: [hdf5/1.10.7]
+      buildable: false
+    
+    python:
+      externals:
+        - spec: python@3.9.2
+          prefix: /apps/python3/3.9.2
+          modules: [python3/3.9.2]
+      buildable: false

--- a/spack.yaml
+++ b/spack.yaml
@@ -57,9 +57,9 @@ spack:
 
     intel-mkl:
       externals:
-      - spec: intel-mkl@2022.2.0
-        prefix: /apps/intel-ct/2022.2.0/mkl
-        modules: [intel-mkl/2022.2.0]
+      - spec: intel-mkl@2020.3.304
+        prefix: /apps/intel-ct/2020.3.304/mkl
+        modules: [intel-mkl/2020.3.304]
       buildable: false
 
     py-cython:

--- a/spack.yaml
+++ b/spack.yaml
@@ -34,9 +34,9 @@ spack:
         modules: [petsc/3.17.4]
       buildable: false
 
-    netcdf:
+    netcdf-c:
       externals:
-      - spec: netcdf@4.8.0
+      - spec: netcdf-c@4.8.0
         prefix: /apps/netcdf/4.8.0p
         modules: [netcdf/4.8.0]
       buildable: false

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,6 @@ spack:
   packages:
     all:
       require:
-        - '%gcc@13'
         - 'target=x86_64'
 
     issm:
@@ -21,54 +20,25 @@ spack:
         - +py-tools
 
     openmpi:
-      externals:
-      - spec: openmpi@4.1.3
-        prefix: /apps/openmpi/4.1.3
-        modules: [openmpi/4.1.3]
-      buildable: false
+      require:
+        - '@4.1.3'
 
     petsc:
-      externals:
-      - spec: petsc@3.17.4
-        prefix: /apps/petsc/3.17.4
-        modules: [petsc/3.17.4]
-      buildable: false
-
+      require:
+        - '@3.17.4'
+    
     netcdf-c:
-      externals:
-      - spec: netcdf-c@4.8.0
-        prefix: /apps/netcdf/4.8.0p
-        modules: [netcdf/4.8.0]
-      buildable: false
+      require:
+        - '@4.8.0p'
 
     hdf5:
-      externals:
-      - spec: hdf5@1.10.7
-        prefix: /apps/hdf5/1.10.7p
-        modules: [hdf5/1.10.7]
-      buildable: false
-    
-    python:
-      externals:
-      - spec: python@3.9.2
-        prefix: /apps/python3/3.9.2
-        modules: [python3/3.9.2]
-        environment:
-          set:
-            LD_LIBRARY_PATH: /apps/python3/3.9.2/lib
-      buildable: false
+      require:
+        - '@1.10.7p'
 
     intel-mkl:
-      externals:
-      - spec: intel-mkl@2020.3.304
-        prefix: /apps/intel-ct/2020.3.304/mkl
-        modules: [intel-mkl/2020.3.304]
-      buildable: false
+      require:
+        - '@2020.3.304'
 
-    py-cython:
-      externals:
-      - spec: py-cython@0.29.22
-        prefix: /apps/python3/3.9.2
-        modules: [python3/3.9.2]
-      buildable: false
-
+    python:
+      require:
+        - '@3.11.7'

--- a/spack.yaml
+++ b/spack.yaml
@@ -23,9 +23,9 @@ spack:
     openmpi:
       externals:
       - spec: openmpi@4.1.3 %gcc
-      prefix: /apps/openmpi/4.1.3
-      modules: [openmpi/4.1.3]
-        buildable: false
+        prefix: /apps/openmpi/4.1.3
+        modules: [openmpi/4.1.3]
+      buildable: false
       extra_attributes:
         environment:
           prepend_path:
@@ -54,7 +54,7 @@ spack:
     
     python:
       externals:
-        - spec: python@3.9.2
-          prefix: /apps/python3/3.9.2
-          modules: [python3/3.9.2]
+      - spec: python@3.9.2
+        prefix: /apps/python3/3.9.2
+        modules: [python3/3.9.2]
       buildable: false

--- a/spack.yaml
+++ b/spack.yaml
@@ -62,3 +62,10 @@ spack:
         modules: [intel-mkl/2022.2.0]
       buildable: false
 
+    py-cython:
+      externals:
+      - spec: py-cython@0.29.22
+        prefix: /apps/python3/3.9.2
+        modules: [python3/3.9.2]
+      buildable: false
+


### PR DESCRIPTION
This PR tests the use of gadi modules wherever possible, to simulate a non-spack build approach.

---
:rocket: The latest prerelease `access-issm/pr29-13` at 015040f81696d1026939d4a20cdaee3d3d207a8f is here: https://github.com/ACCESS-NRI/ACCESS-ISSM/pull/29#issuecomment-3471344095 :rocket:













