### PR TITLE
Infra Update `v8`: `spack v1` Support

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,11 +10,11 @@ on:
 jobs:
   cd:
     name: CD
-    uses: access-nri/build-cd/.github/workflows/cd.yml@v7
+    uses: access-nri/build-cd/.github/workflows/cd.yml@v8
     with:
       model: ${{ vars.NAME }}
-      spack-manifest-schema-version: 1-0-7
-      config-versions-schema-version: 3-0-0
+      spack-manifest-schema-version: 2-0-0
+      config-versions-schema-version: 4-0-0
       config-packages-schema-version: 1-0-0
     permissions:
       contents: write

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   cd:
     name: CD
-    uses: access-nri/build-cd/.github/workflows/cd.yml@v8
+    uses: access-nri/build-cd/.github/workflows/cd.yml@test-v8
     with:
       model: ${{ vars.NAME }}
       spack-manifest-schema-version: 2-0-0

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   cd:
     name: CD
-    uses: access-nri/build-cd/.github/workflows/cd.yml@test-v8
+    uses: access-nri/build-cd/.github/workflows/cd.yml@v8
     with:
       model: ${{ vars.NAME }}
       spack-manifest-schema-version: 2-0-0

--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -8,12 +8,11 @@ jobs:
   redeploy:
     name: Redeploy
     if: startsWith(github.event.comment.body, '!redeploy') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci.yml@v7
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v8
     with:
       model: ${{ vars.NAME }}
-      pr: ${{ github.event.issue.number }}
-      spack-manifest-schema-version: 1-0-7
-      config-versions-schema-version: 3-0-0
+      spack-manifest-schema-version: 2-0-0
+      config-versions-schema-version: 4-0-0
       config-packages-schema-version: 1-0-0
     permissions:
       pull-requests: write
@@ -23,7 +22,7 @@ jobs:
   bump:
     name: Bump
     if: startsWith(github.event.comment.body, '!bump') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v7
+    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v8
     with:
       model: ${{ vars.NAME }}
     permissions:
@@ -33,7 +32,7 @@ jobs:
   configs:
     name: Configs
     if: startsWith(github.event.comment.body, '!update-configs') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci-command-configs.yml@v7
+    uses: access-nri/build-cd/.github/workflows/ci-command-configs.yml@v8
     with:
       model: ${{ vars.NAME }}
       auto-configs-pr-schema-version: 1-0-0

--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -8,7 +8,7 @@ jobs:
   redeploy:
     name: Redeploy
     if: startsWith(github.event.comment.body, '!redeploy') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci.yml@v8
+    uses: access-nri/build-cd/.github/workflows/ci.yml@test-v8
     with:
       model: ${{ vars.NAME }}
       spack-manifest-schema-version: 2-0-0
@@ -22,7 +22,7 @@ jobs:
   bump:
     name: Bump
     if: startsWith(github.event.comment.body, '!bump') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v8
+    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@test-v8
     with:
       model: ${{ vars.NAME }}
     permissions:
@@ -32,7 +32,7 @@ jobs:
   configs:
     name: Configs
     if: startsWith(github.event.comment.body, '!update-configs') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci-command-configs.yml@v8
+    uses: access-nri/build-cd/.github/workflows/ci-command-configs.yml@test-v8
     with:
       model: ${{ vars.NAME }}
       auto-configs-pr-schema-version: 1-0-0

--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -8,7 +8,7 @@ jobs:
   redeploy:
     name: Redeploy
     if: startsWith(github.event.comment.body, '!redeploy') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci.yml@test-v8
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v8
     with:
       model: ${{ vars.NAME }}
       spack-manifest-schema-version: 2-0-0
@@ -22,7 +22,7 @@ jobs:
   bump:
     name: Bump
     if: startsWith(github.event.comment.body, '!bump') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@test-v8
+    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v8
     with:
       model: ${{ vars.NAME }}
     permissions:
@@ -32,7 +32,7 @@ jobs:
   configs:
     name: Configs
     if: startsWith(github.event.comment.body, '!update-configs') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci-command-configs.yml@test-v8
+    uses: access-nri/build-cd/.github/workflows/ci-command-configs.yml@v8
     with:
       model: ${{ vars.NAME }}
       auto-configs-pr-schema-version: 1-0-0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
   pr-ci:
     name: CI
     if: github.event.action != 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci.yml@v8
+    uses: access-nri/build-cd/.github/workflows/ci.yml@test-v8
     with:
       model: ${{ vars.NAME }}
       spack-manifest-schema-version: 2-0-0
@@ -34,5 +34,5 @@ jobs:
   pr-closed:
     name: Closed
     if: github.event.action == 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v8
+    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@test-v8
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,15 +19,14 @@ on:
 jobs:
   pr-ci:
     name: CI
-    if: >-
-      github.event.action != 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci.yml@v7
+    if: github.event.action != 'closed'
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v8
     with:
       model: ${{ vars.NAME }}
       # root-sbd: if different from vars.NAME
       pr: ${{ github.event.pull_request.number }}
-      spack-manifest-schema-version: 1-0-7
-      config-versions-schema-version: 3-0-0
+      spack-manifest-schema-version: 2-0-0
+      config-versions-schema-version: 4-0-0
       config-packages-schema-version: 1-0-0
     permissions:
       pull-requests: write
@@ -37,7 +36,7 @@ jobs:
   pr-closed:
     name: Closed
     if: github.event.action == 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v7
+    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v8
     with:
       root-sbd: ${{ vars.NAME }} # or something else, if different from vars.NAME
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
   pr-ci:
     name: CI
     if: github.event.action != 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci.yml@test-v8
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v8
     with:
       model: ${{ vars.NAME }}
       spack-manifest-schema-version: 2-0-0
@@ -34,5 +34,5 @@ jobs:
   pr-closed:
     name: Closed
     if: github.event.action == 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@test-v8
+    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v8
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,6 @@ jobs:
     uses: access-nri/build-cd/.github/workflows/ci.yml@v8
     with:
       model: ${{ vars.NAME }}
-      # root-sbd: if different from vars.NAME
-      pr: ${{ github.event.pull_request.number }}
       spack-manifest-schema-version: 2-0-0
       config-versions-schema-version: 4-0-0
       config-packages-schema-version: 1-0-0
@@ -37,6 +35,4 @@ jobs:
     name: Closed
     if: github.event.action == 'closed'
     uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v8
-    with:
-      root-sbd: ${{ vars.NAME }} # or something else, if different from vars.NAME
     secrets: inherit

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
-  "spack": "1.0",
+  "spack": "1.1",
   "access-spack-packages": "2025.11.002"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
-    "spack": "0.22",
-    "spack-packages": "2025.11.002"
+  "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
+  "spack": "1.0",
+  "access-spack-packages": "2025.11.002"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2026.03.000"
+  "access-spack-packages": "2026.03.001"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2026.02.002"
+  "access-spack-packages": "2026.03.000"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2025.11.002"
+  "access-spack-packages": "2026.02.002"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -1,75 +1,75 @@
 spack:
   specs:
-    - access-issm@git.2025.11.0
+  - access-issm@git.2025.11.0
   packages:
     issm:
       require:
-        - '@git.2025.11.24'
-        - +wrappers
-        - +py-tools
-        - ~ad
+      - '@git.2025.11.24'
+      - +wrappers
+      - +py-tools
+      - ~ad
 
     python:
       require:
-        - '@3.11.7'
+      - '@3.11.7'
 
     py-numpy:
       require:
-        - '@1.26.4'
+      - '@1.26.4'
 
     openmpi:
       require:
-        - '@4.1.3'
+      - '@4.1.3'
 
     access-triangle:
       require:
-        - '@1.6.1'
+      - '@1.6.1'
 
     petsc:
       require:
-        - '@3.21.1'
+      - '@3.21.1'
 
     metis:
       require:
-        - '@5.1.0'
+      - '@5.1.0'
 
     mumps:
       require:
-        - '@5.6.2'
+      - '@5.6.2'
 
     parmetis:
       require:
-        - '@4.0.3'
+      - '@4.0.3'
 
     scalapack:
       require:
-        - '@2.2.0'
+      - '@2.2.0'
 
     autoconf:
       require:
-        - '@2.72'
+      - '@2.72'
 
     automake:
       require:
-        - '@1.16.5'
+      - '@1.16.5'
 
     libtool:
       require:
-        - '@2.4.7'
+      - '@2.4.7'
 
     m4:
       require:
-        - '@1.4.19'
+      - '@1.4.19'
 
     m1qn3:
       require:
-        - '@3.3'
+      - '@3.3'
 
     # “all” can remain empty if you aren’t forcing any particular compiler / MPI
     all:
       require:
-        - '%gcc@13'
-        - 'target=x86_64'
+      - '%gcc@13'
+      - 'target=x86_64'
   # Create a unified view of all installed packages
   view: true
   # Make the solver unify dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,7 +22,7 @@ spack:
 
     openmpi:
       require:
-      - '@4.1.3'
+      - '@4.1.7'
 
     access-triangle:
       require:
@@ -68,10 +68,14 @@ spack:
       require:
       - '@3.3'
 
+    # Compilers
+    gcc:
+      require:
+      - '@13'
     # “all” can remain empty if you aren’t forcing any particular compiler / MPI
     all:
       require:
-      - '%gcc@13'
+      - '%access_gcc'
       - 'target=x86_64'
   # Create a unified view of all installed packages
   view: true

--- a/spack.yaml
+++ b/spack.yaml
@@ -1,6 +1,9 @@
 spack:
+  definitions:
+  - _name: [access-issm]
+  - _version: [2025.11.0]
   specs:
-  - access-issm@git.2025.11.0
+  - access-issm
   packages:
     issm:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -14,7 +14,7 @@ spack:
 
     python:
       require:
-      - '@3.11.11'
+      - '@3.11.14'
 
     py-numpy:
       require:
@@ -44,9 +44,9 @@ spack:
       require:
       - '@4.0.3'
 
-    netlib-scalapack:
+    scalapack:
       require:
-      - '@2.2.0'
+      - 'netlib-scalapack@2.2.0'
 
     autoconf:
       require:
@@ -67,6 +67,11 @@ spack:
     m1qn3:
       require:
       - '@3.3'
+
+    # Wokaround due to https://github.com/spack/spack-packages/pull/3644
+    re2c:
+      require:
+      - '@3.1'
 
     # Compilers
     c:

--- a/spack.yaml
+++ b/spack.yaml
@@ -69,13 +69,19 @@ spack:
       - '@3.3'
 
     # Compilers
-    gcc:
+    c:
       require:
-      - '@13'
+      - 'gcc@13'
+    cxx:
+      require:
+      - 'gcc@13'
+    fortran:
+      require:
+      - 'gcc@13'
+
     # “all” can remain empty if you aren’t forcing any particular compiler / MPI
     all:
-      require:
-      - '%access_gcc'
+      prefer:
       - 'target=x86_64'
   # Create a unified view of all installed packages
   view: true

--- a/spack.yaml
+++ b/spack.yaml
@@ -22,7 +22,7 @@ spack:
 
     openmpi:
       require:
-      - '@4.1.7'
+      - '@4.1.5'
 
     access-triangle:
       require:
@@ -71,13 +71,13 @@ spack:
     # Compilers
     c:
       require:
-      - 'gcc@13'
+      - 'gcc@13.2.0'
     cxx:
       require:
-      - 'gcc@13'
+      - 'gcc@13.2.0'
     fortran:
       require:
-      - 'gcc@13'
+      - 'gcc@13.2.0'
 
     # “all” can remain empty if you aren’t forcing any particular compiler / MPI
     all:

--- a/spack.yaml
+++ b/spack.yaml
@@ -44,9 +44,9 @@ spack:
       require:
       - '@4.0.3'
 
-    scalapack:
+    netlib-scalapack:
       require:
-      - 'netlib-scalapack@2.2.0'
+      - '@2.2.0'
 
     autoconf:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -14,7 +14,7 @@ spack:
 
     python:
       require:
-      - '@3.11.7'
+      - '@3.11.11'
 
     py-numpy:
       require:
@@ -44,7 +44,7 @@ spack:
       require:
       - '@4.0.3'
 
-    scalapack:
+    netlib-scalapack:
       require:
       - '@2.2.0'
 


### PR DESCRIPTION
References issue ACCESS-NRI/build-cd#313 and PR ACCESS-NRI/build-cd#326
References rollout issue ACCESS-NRI/build-cd#328
References project https://github.com/orgs/ACCESS-NRI/projects/37

> [!IMPORTANT]
> This PR is a major update to the deployment infrastructure. See below for the prerequisites for this repository to be able to merge this PR.

> [!IMPORTANT]
> This major version change marks the end of major infrastructure updates for deployments to `spack < 1.0`.
> If you want to deploy to instances of `spack < 1.0`, you must use `build-cd < v8`.
> If you want to deploy to instances of `spack >= 1.0`, you must use `build-cd >= v8`.

## Background

We are moving on up to `spack v1`! This update to spack contains many bug fixes, optimisations and new features that can be incorporated into `build-cd`.

This update also contains changes that make `spack v0.X` incompatible with this `build-cd v8` update - the most prominent one being the splitting of spacks core codebase from it's builtin spack-packages repo. This means that for provenance, one to keep track of both `builtin` spack-packages and our own, renamed `access-spack-packages`. `build-cd` will centrally control the version of builtin `spack-packages` for a given instance, and `config/versions.json`s `spack-packages` key is renamed to `access-spack-packages`.

As noted earlier, this major version of `build-cd` can only support `spack v1`, due to `spack v1`-specific commands in the infrastructure. If you still want to deploy to `spack v0.X`, you will need to change `build-cd` to `v7`, and update the `config/versions.json` file/`spack.yaml`.

## Features

* **Support for spack v1**: We're moving to a new, non-beta version of spack! It contains bug fixes, features and optimisations over the old version.

## Prerequisites for Merging

- [x] Update `build-cd` entrypoints (this PR!)
- [x] Update `config/versions.json` with new inputs (also this PR!)
- [x] Validate compiler additions to the spack manifest (this PR, too!)
- [x] Test and Verify Model built with `spack v1`


---
:rocket: The latest prerelease `access-issm/pr32-14` at 0eb7e09d62512f7aea23b0ac61d624f65fa3013f is here: https://github.com/ACCESS-NRI/ACCESS-ISSM/pull/32#issuecomment-4009545114 :rocket:














