### PR TITLE
2025.11.0 - ISSM build with AD (`+ad`)

### DIFF
--- a/config/packages.json
+++ b/config/packages.json
@@ -5,6 +5,7 @@
   ],
   "injection": [
     "openmpi",
-    "access-triangle"
+    "access-triangle",
+    "python"
   ]
 }

--- a/config/packages.json
+++ b/config/packages.json
@@ -5,7 +5,6 @@
   ],
   "injection": [
     "openmpi",
-    "access-triangle",
-    "python"
+    "access-triangle"
   ]
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "75725e8cf7b7c22dcb953e4f83b6207ad05432ef"
+    "spack-packages": "2025.11.002"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.10.001"
+    "spack-packages": "3ae3eac7206c342746cfb439bda0e520569d60ae"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "885512440fff06778a2af123b79966aad0c59747"
+    "spack-packages": "fa03720921ae83f76969ec9a5a0e9fa3aada2e0b"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "18023830aa6b9b83fe9cae286c38a2edb028b4f5"
+    "spack-packages": "2a25da0519bc320048ebf008e73b4c484821fd63"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "fa03720921ae83f76969ec9a5a0e9fa3aada2e0b"
+    "spack-packages": "18023830aa6b9b83fe9cae286c38a2edb028b4f5"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "dd7c66b86d1d78806ffbf43676878a9fa7a12979"
+    "spack-packages": "885512440fff06778a2af123b79966aad0c59747"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "017a707970593afe70da5936650286799575c671"
+    "spack-packages": "3cd195042451007904757efb93e6f5b3e5626b12"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "6546697fc01bcd7ce782f1c9cd75fb00d5e02686"
+    "spack-packages": "7e5628cbe6659baf27255d414828d2c708d8b36e"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.04.001"
+    "spack-packages": "2025.10.001"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "3cd195042451007904757efb93e6f5b3e5626b12"
+    "spack-packages": "75725e8cf7b7c22dcb953e4f83b6207ad05432ef"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2a25da0519bc320048ebf008e73b4c484821fd63"
+    "spack-packages": "6546697fc01bcd7ce782f1c9cd75fb00d5e02686"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "cb365a757349fef93b15f92ad43eb4ab64b981a7"
+    "spack-packages": "dd7c66b86d1d78806ffbf43676878a9fa7a12979"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "86c97e8078ab7a7dbc3497b7c937082ac5bc7c5f"
+    "spack-packages": "cb365a757349fef93b15f92ad43eb4ab64b981a7"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "7e5628cbe6659baf27255d414828d2c708d8b36e"
+    "spack-packages": "017a707970593afe70da5936650286799575c671"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "3ae3eac7206c342746cfb439bda0e520569d60ae"
+    "spack-packages": "86c97e8078ab7a7dbc3497b7c937082ac5bc7c5f"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -7,17 +7,63 @@ spack:
         - '@git.2025.11.06'
         - +wrappers
         - +py-tools
+
     python:
-      externals:
-        - spec: python@3.9.2
-          modules:
-            - python3/3.9.2
-          prefix: /apps/python3/3.9.2
-      buildable: false
-      
+      require:
+        - '@3.11.14'
+
+    py-numpy:
+      require:
+        - '@1.26.4'
+
     openmpi:
       require:
         - '@4.1.3'
+
+    access-triangle:
+      require:
+        - '@1.6.1'
+
+    petsc:
+      require:
+        - '@3.21.1'
+
+    metis:
+      require:
+        - '@5.1.0'
+
+    mumps:
+      require:
+        - '@5.6.2'
+
+    parmetis:
+      require:
+        - '@4.0.3'
+
+    scalapack:
+      require:
+        - '@2.2.0'
+
+    autoconf:
+      require:
+        - '@2.72'
+
+    automake:
+      require:
+        - '@1.16.5'
+
+    libtool:
+      require:
+        - '@2.4.7'
+
+    m4:
+      require:
+        - '@1.4.19'
+
+    m1qn3:
+      require:
+        - '@3.3'
+
     # “all” can remain empty if you aren’t forcing any particular compiler / MPI
     all:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,6 +6,7 @@ spack:
       require:
         - '@git.2025.04.11'
         - +wrappers
+        - +py-tools
     # Mark Python 3.9.2 as external so Spack reuses the system module
     python:
       externals:

--- a/spack.yaml
+++ b/spack.yaml
@@ -4,19 +4,14 @@ spack:
   packages:
     issm:
       require:
-        - '@git.4a8c078eefe06f23665322e153b35f8594b4e626'
+        - '@git.8aa05ae77bfb1e99eeff14df033709f9ab2c20ce'
         - +wrappers
         - +py-tools
         - +ad
-        - ~openmp
     # Mark Python 3.9.2 as external so Spack reuses the system module
     python:
-      externals:
-        - spec: python@3.9.2
-          modules:
-            - python3/3.9.2
-          prefix: /apps/python3/3.9.2
-      buildable: false
+      require:
+        - '@3.11.7'
     openmpi:
       require:
         - '@4.1.3'

--- a/spack.yaml
+++ b/spack.yaml
@@ -7,7 +7,7 @@ spack:
         - '@git.2025.11.24'
         - +wrappers
         - +py-tools
-        - ~ad
+        - +ad
 
     python:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,14 +16,8 @@ spack:
           prefix: /apps/python3/3.9.2
       buildable: false
     openmpi:
-      externals:
-        - spec: openmpi@4.1.3
-          modules:
-            - openmpi/4.1.3
-          prefix: /apps/openmpi/4.1.3
-      buildable: false
-      # require:
-      #   - '@4.1.7'
+      require:
+        - '@4.1.3'
     # “all” can remain empty if you aren’t forcing any particular compiler / MPI
     all:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,6 +15,8 @@ spack:
             - python3/3.11.7
           prefix: /apps/python3/3.11.7
       buildable: false
+      require:
+        - '@3.11.7'
 
     py-numpy:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -7,7 +7,7 @@ spack:
         - '@git.2025.11.06'
         - +wrappers
         - +py-tools
-        - ~ad
+        - +ad
 
     python:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -1,21 +1,15 @@
 spack:
   specs:
-    - access-issm@git.2025.03.0
+    - access-issm@git.2025.11.0
   packages:
     issm:
       require:
-        - '@git.8aa05ae77bfb1e99eeff14df033709f9ab2c20ce'
+        - '@git.2025.11.06'
         - +wrappers
         - +py-tools
     python:
       require:
-        - '@3.11.7'
-    
-    py-numpy:
-      externals:
-        - spec: 'py-numpy'
-          prefix: /apps/python3/3.11.7/lib/python3.11/site-packages/numpy
-      buildable: True
+        - '@3.9.2'
       
     openmpi:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,8 +16,14 @@ spack:
           prefix: /apps/python3/3.9.2
       buildable: false
     openmpi:
-      require:
-        - '@4.1.7'
+      externals:
+        - spec: openmpi@4.1.3
+          modules:
+            - openmpi/4.1.3
+          prefix: /apps/openmpi/4.1.3
+      buildable: false
+      # require:
+      #   - '@4.1.7'
     # “all” can remain empty if you aren’t forcing any particular compiler / MPI
     all:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -7,11 +7,16 @@ spack:
         - '@git.8aa05ae77bfb1e99eeff14df033709f9ab2c20ce'
         - +wrappers
         - +py-tools
-        - +ad
-    # Mark Python 3.9.2 as external so Spack reuses the system module
     python:
       require:
         - '@3.11.7'
+    
+    py-numpy:
+      externals:
+        - spec: 'py-numpy'
+          prefix: /apps/python3/3.11.7/lib/python3.11/site-packages/numpy
+      buildable: True
+      
     openmpi:
       require:
         - '@4.1.3'

--- a/spack.yaml
+++ b/spack.yaml
@@ -4,7 +4,7 @@ spack:
   packages:
     issm:
       require:
-        - '@git.2025.04.11'
+        - '@git.d52ab3f049920f1a5b0432938f1279ba09c3a8cf'
         - +wrappers
         - +py-tools
     # Mark Python 3.9.2 as external so Spack reuses the system module

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,12 +9,6 @@ spack:
         - +py-tools
 
     python:
-      externals:
-        - spec: python@3.11.7
-          modules:
-            - python3/3.11.7
-          prefix: /apps/python3/3.11.7
-      buildable: false
       require:
         - '@3.11.7'
 

--- a/spack.yaml
+++ b/spack.yaml
@@ -4,7 +4,7 @@ spack:
   packages:
     issm:
       require:
-        - '@git.d52ab3f049920f1a5b0432938f1279ba09c3a8cf'
+        - '@git.4a8c078eefe06f23665322e153b35f8594b4e626'
         - +wrappers
         - +py-tools
         - +ad

--- a/spack.yaml
+++ b/spack.yaml
@@ -10,10 +10,10 @@ spack:
 
     python:
       externals:
-        - spec: python@3.9.2
+        - spec: python@3.11.7
           modules:
-            - python3/3.9.2
-          prefix: /apps/python3/3.9.2
+            - python3/3.11.7
+          prefix: /apps/python3/3.11.7
       buildable: false
 
     py-numpy:

--- a/spack.yaml
+++ b/spack.yaml
@@ -7,6 +7,7 @@ spack:
         - '@git.2025.11.06'
         - +wrappers
         - +py-tools
+        - ~ad
 
     python:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -4,10 +4,10 @@ spack:
   packages:
     issm:
       require:
-        - '@git.2025.11.06'
+        - '@git.2025.11.24'
         - +wrappers
         - +py-tools
-        - +ad
+        - ~ad
 
     python:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,8 +9,12 @@ spack:
         - +py-tools
 
     python:
-      require:
-        - '@3.11.14'
+      externals:
+        - spec: python@3.9.2
+          modules:
+            - python3/3.9.2
+          prefix: /apps/python3/3.9.2
+      buildable: false
 
     py-numpy:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -8,8 +8,12 @@ spack:
         - +wrappers
         - +py-tools
     python:
-      require:
-        - '@3.9.2'
+      externals:
+        - spec: python@3.9.2
+          modules:
+            - python3/3.9.2
+          prefix: /apps/python3/3.9.2
+      buildable: false
       
     openmpi:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -7,6 +7,8 @@ spack:
         - '@git.d52ab3f049920f1a5b0432938f1279ba09c3a8cf'
         - +wrappers
         - +py-tools
+        - +ad
+        - ~openmp
     # Mark Python 3.9.2 as external so Spack reuses the system module
     python:
       externals:


### PR DESCRIPTION
This PR provides a persistent Pre-release build of ISSM with AD (`+ad`). This is consistent with ACCESS-ISSM `2025.11.0`, but with AD enabled. 

This PR:
- Follows considerable testing completed in #28 .

---
:rocket: The latest prerelease `access-issm/pr34-4` at 93b9d88c95a5a229934231108dd2bc50c8f26b45 is here: https://github.com/ACCESS-NRI/ACCESS-ISSM/pull/34#issuecomment-3573543005 :rocket:



