### PR TITLE
ISSM NUOPC prerelease deployment

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2026.03.001"
+  "access-spack-packages": "jr/issm_nuopc_v1"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -7,7 +7,8 @@ spack:
   packages:
     issm:
       require:
-      - '@git.2025.11.24'
+      - '@issm-nuopc-v1'
+      - +nuopc
       - +wrappers
       - +py-tools
       - ~ad
@@ -23,6 +24,10 @@ spack:
     openmpi:
       require:
       - '@4.1.5'
+
+    esmf:
+      require:
+      - '@8.7.0'
 
     access-triangle:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -1,7 +1,7 @@
 spack:
   definitions:
   - _name: [access-issm]
-  - _version: [2025.11.0]
+  - _version: [2026.05.19]
   specs:
   - access-issm
   packages:


### PR DESCRIPTION
This is a first pass at adding a NUOPC cap to the ISSM deployment. Local Spack build runs MISMIP successfully using the issm.exe. 

Still need to test a mediator driven ISSM toy run through the added NUOPC cap. 

---
:rocket: The latest prerelease `access-issm/pr42-1` at a7fa4273f5e6396bc1c77abe7c8b06b532450505 is here: https://github.com/ACCESS-NRI/ACCESS-ISSM/pull/42#issuecomment-4484653289 :rocket:

